### PR TITLE
fix: gate macos ActivationPolicy

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use player::Player;
+#[cfg(target_os = "macos")]
 use tauri::ActivationPolicy;
 use std::sync::Mutex;
 


### PR DESCRIPTION
this makes it compile on windows.

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.68s
     Running `target\debug\retropulse.exe`
 ✓ Ready in 2.4s
 ○ Compiling / ...
 ✓ Compiled / in 1421ms (568 modules)
 GET / 200 in 1812ms
 ✓ Compiled in 304ms (279 modules)
Subscribing to player events
[src\commands.rs:46:5] player.lock().unwrap().subscribe_to_events(channel) = "9cba65d5-8647-4065-9f74-f317f06da3a6"
Subscribing to player events
[src\commands.rs:46:5] player.lock().unwrap().subscribe_to_events(channel) = "e8837b1c-ff41-4ea7-be6a-9506929949f4"
Unsubscribing from player events with 9cba65d5-8647-4065-9f74-f317f06da3a6
[src\commands.rs:52:5] player.lock().unwrap().unsubscribe_from_events(id) = true

```

I do not see a window or a tray icon so Im not sure where to go, but that include is gated for macos.